### PR TITLE
Improve request state transition on useResource

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "deploy": "gh-pages -d example/build",
     "prepare": "yarn run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "fast-deep-equal": "^2.0.1"
+  },
   "peerDependencies": {
     "axios": "^0.18.0",
     "react": "^16.7.0-alpha.2",

--- a/src/__tests__/useRequest.spec.tsx
+++ b/src/__tests__/useRequest.spec.tsx
@@ -224,6 +224,33 @@ describe('useRequest', () => {
     });
   });
 
+  it('uses the last returned axios config', async () => {
+    const Component = () => {
+      const [endpoint, setEndpoint] = React.useState('endpoint-1');
+      React.useEffect(() => setEndpoint('endpoint-2'), []);
+      const [, request] = useRequest(() => ({
+        url: `/${endpoint}`,
+        method: 'get',
+      }));
+
+      React.useEffect(() => {
+        request().ready();
+      }, [endpoint, request]);
+
+      return null;
+    };
+
+    render(
+      <RequestProvider value={axios}>
+        <Component />
+      </RequestProvider>,
+    );
+
+    await wait(() => expect(adapter.history.get.length).toEqual(2));
+    expect(adapter.history.get[0].url).toEqual('/endpoint-1');
+    expect(adapter.history.get[1].url).toEqual('/endpoint-2');
+  });
+
   it('should use the lastest axios instance', async () => {
     const instance1 = adapter.axiosInstance.create({
       baseURL: 'https://instance1',
@@ -251,7 +278,7 @@ describe('useRequest', () => {
         usedInstances++;
         request().ready();
         request().ready();
-      }, [current]);
+      }, [current, request]);
 
       return null;
     };

--- a/src/__tests__/useRequest.spec.tsx
+++ b/src/__tests__/useRequest.spec.tsx
@@ -309,4 +309,15 @@ describe('useRequest', () => {
       expect(countInstance2).toBe(2);
     });
   });
+
+  it('throws if provider is missing', () => {
+    const Component = () => {
+      expect(() => {
+        useRequest(() => ({url: ''}));
+      }).toThrow();
+      return null;
+    };
+
+    render(<Component />);
+  });
 });

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -21,10 +21,23 @@ export type UseRequestResult<TRequest extends Request> = [
   RequestFactory<TRequest>
 ];
 
+class MissingProviderError extends Error {
+  constructor() {
+    super(
+      'react-request-hook requires an Axios instance to be passed through ' +
+        'context via the <RequestProvider>',
+    );
+  }
+}
+
 export function useRequest<TRequest extends Request>(
   fn: TRequest,
 ): UseRequestResult<TRequest> {
   const axiosInstance = useContext(RequestContext);
+  if (!axiosInstance) {
+    throw new MissingProviderError();
+  }
+
   const [sources, setSources] = useState<CancelTokenSource[]>([]);
   const mountedRef = useRef(true);
 

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -36,9 +36,14 @@ export function useRequest<TRequest extends Request>(
     }
   };
 
+  const callFn = useRef(fn);
+  useEffect(() => {
+    callFn.current = fn;
+  }, [fn]);
+
   const request = useCallback(
     (...args: Arguments<TRequest> | any[]) => {
-      const config = fn(...args);
+      const config = callFn.current(...args);
       const source = axios.CancelToken.source();
 
       const ready = () => {
@@ -89,7 +94,7 @@ export function useRequest<TRequest extends Request>(
 
   return [
     {
-      clear: (message?: string) => clearRef.current(message),
+      clear,
       hasPending: sources.length > 0,
     },
     request,

--- a/src/useRequest.ts
+++ b/src/useRequest.ts
@@ -107,7 +107,7 @@ export function useRequest<TRequest extends Request>(
 
   return [
     {
-      clear,
+      clear: (message?: string) => clearRef.current(message),
       hasPending: sources.length > 0,
     },
     request,

--- a/src/useResource.ts
+++ b/src/useResource.ts
@@ -1,4 +1,5 @@
-import {useEffect, useState, useCallback} from 'react';
+import {useEffect, useCallback, useRef, useReducer, useMemo} from 'react';
+import isEqual from 'fast-deep-equal';
 import {Canceler} from 'axios';
 import {useRequest} from './useRequest';
 import {
@@ -9,48 +10,75 @@ import {
   Arguments,
 } from './request';
 
+const REQUEST_CLEAR_MESSAGE =
+  'A new request has been made before completing the last one';
+
+type RequestState<TRequest extends Request> = {
+  data: Payload<TRequest> | null;
+  error: RequestError | null;
+  isLoading: boolean;
+};
+
 export type UseResourceResult<TRequest extends Request> = [
-  {
-    data: Payload<TRequest> | null;
-    error: RequestError | null;
-    isLoading: boolean;
-    cancel: Canceler;
-  },
+  RequestState<TRequest> & {cancel: Canceler},
   RequestDispatcher<TRequest>
 ];
 
-const REQUEST_CLEAR_MESSAGE =
-  'A new request has been made before completing the last one';
+type Action =
+  | {type: 'success'; data: any}
+  | {type: 'error'; error: RequestError}
+  | {type: 'reset' | 'start'};
+
+function getNextState(state: RequestState<any>, action: Action) {
+  return {
+    data: action.type === 'success' ? action.data : state.data,
+    error: action.type === 'error' ? action.error : null,
+    isLoading: action.type === 'start' ? true : false,
+  };
+}
 
 export function useResource<TRequest extends Request>(
   fn: TRequest,
   defaultParams?: Arguments<TRequest>,
 ): UseResourceResult<TRequest> {
-  const [{clear, hasPending}, createRequest] = useRequest(fn);
-  const [error, setError] = useState<RequestError | null>(null);
-  const [data, setData] = useState<Payload<TRequest> | null>(null);
+  const [{clear}, createRequest] = useRequest(fn);
+
+  const [state, dispatch] = useReducer(getNextState, {
+    error: null,
+    data: null,
+    isLoading: Boolean(defaultParams),
+  });
+
+  const lastAppliedParams = useRef<Arguments<TRequest> | null>(null);
 
   const request = useCallback(
     (...args: Arguments<TRequest> | any[]) => {
       clear(REQUEST_CLEAR_MESSAGE);
       const {ready, cancel} = createRequest(...(args as Arguments<TRequest>));
+      dispatch({type: 'start'});
       ready()
         .then(data => {
-          setData(data);
+          dispatch({type: 'success', data});
         })
         .catch((error: RequestError) => {
           if (!error.isCancel) {
-            setError(error);
+            dispatch({type: 'error', error});
           }
         });
       return cancel;
     },
-    [clear, createRequest],
+    [createRequest],
   );
+
+  const cancel = (message?: string) => {
+    dispatch({type: 'reset'});
+    clear(message);
+  };
 
   useEffect(() => {
     let canceller: Canceler;
-    if (defaultParams) {
+    if (defaultParams && !isEqual(defaultParams, lastAppliedParams.current)) {
+      lastAppliedParams.current = defaultParams;
       canceller = request(...defaultParams);
     }
     return () => {
@@ -60,13 +88,8 @@ export function useResource<TRequest extends Request>(
     };
   }, defaultParams);
 
-  return [
-    {
-      data,
-      error,
-      cancel: clear,
-      isLoading: hasPending,
-    },
-    request,
-  ];
+  return useMemo(() => {
+    const result: UseResourceResult<TRequest> = [{...state, cancel}, request];
+    return result;
+  }, [state, request]);
 }

--- a/src/useResource.ts
+++ b/src/useResource.ts
@@ -19,6 +19,9 @@ export type UseResourceResult<TRequest extends Request> = [
   RequestDispatcher<TRequest>
 ];
 
+const REQUEST_CLEAR_MESSAGE =
+  'A new request has been made before completing the last one';
+
 export function useResource<TRequest extends Request>(
   fn: TRequest,
   defaultParams?: Arguments<TRequest>,
@@ -27,20 +30,23 @@ export function useResource<TRequest extends Request>(
   const [error, setError] = useState<RequestError | null>(null);
   const [data, setData] = useState<Payload<TRequest> | null>(null);
 
-  const request = useCallback((...args: Arguments<TRequest> | any[]) => {
-    clear('A new request has been made before completing the last one');
-    const {ready, cancel} = createRequest(...(args as Arguments<TRequest>));
-    ready()
-      .then(data => {
-        setData(data);
-      })
-      .catch((error: RequestError) => {
-        if (!error.isCancel) {
-          setError(error);
-        }
-      });
-    return cancel;
-  }, []);
+  const request = useCallback(
+    (...args: Arguments<TRequest> | any[]) => {
+      clear(REQUEST_CLEAR_MESSAGE);
+      const {ready, cancel} = createRequest(...(args as Arguments<TRequest>));
+      ready()
+        .then(data => {
+          setData(data);
+        })
+        .catch((error: RequestError) => {
+          if (!error.isCancel) {
+            setError(error);
+          }
+        });
+      return cancel;
+    },
+    [clear, createRequest],
+  );
 
   useEffect(() => {
     let canceller: Canceler;


### PR DESCRIPTION
This PR adds useReducer to the useResource hook to improve the way we keep track of the request state. Before, we're relying on the property `hasPending` from useRequest to set the `isLoading`. However, when using the hook with default request params, which makes an API call to be triggered right away, the `isLoading` was being initialized with false.

Also, the equality check of the default request params (if any), was delegated to be treated by React itself (passing the param down to our internal useEffect). However, an user messing with nested objects could trigger unwanted API calls, if happens that the changed object has only references changed, but not its values. we now use https://github.com/epoberezkin/fast-deep-equal to handle those cases.

