### PR TITLE
Specify types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
+  "types": "dist/src/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=5"


### PR DESCRIPTION
With the current version, I'm able to import the library with something like

```ts
import { useResource } from 'react-request-hooks';
```

But in order to get types, I need to import
```ts
import { useResource } from 'react-request-hooks/dist/src';
```
which doesn't exist for the bundled code, so I can't use TypeScript with the app. This PR adds the `types` property to the package which fixes this. I've added it in my local installed version and can verify it all works as expected.