### PR TITLE
doc: missing ending parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ function UserProfile(props) {
   const [profile, getProfile] = useResource(id => ({
     url: `/user/${id}`,
     method: 'GET'
-  })
+  }))
 
   useEffect(() => getProfile(props.userId), [])
 


### PR DESCRIPTION
Hey 👋 
Copy-Pasting readme example leads to syntax error due to a missing parenthesis so I fixed it