### PR TITLE
Feat: block state update on unmounted components

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+import {useRef, useEffect, useCallback} from 'react';
+
+/**
+ * useMountedState
+ */
+export function useMountedState(): () => boolean {
+  const mountedRef = useRef<boolean>(false);
+
+  const getMounted = useCallback(() => mountedRef.current, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+    };
+  });
+
+  return getMounted;
+}


### PR DESCRIPTION
> Warning: Can’t perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.

1. feat(utils): useMountedState hook;
2. fix: block state update on unmounted components